### PR TITLE
Allow binding text attr as a callback function

### DIFF
--- a/angular-circles.js
+++ b/angular-circles.js
@@ -149,7 +149,7 @@
                 value: '=',
                 maxValue: '@',
                 width: '@',
-                text: '@',
+                text: '&',
                 colors: '=',
                 duration: '@',
                 wrpClass: '@',


### PR DESCRIPTION
Use `&` instead of `@` for binding the `ngCircles` directive's `text` attribute. This allows passing a callback function to the attribute, as described in [the original usage documentation](https://github.com/lugolabs/circles#usage).